### PR TITLE
removing references to the contract attributes

### DIFF
--- a/gcc/cp/contracts.cc
+++ b/gcc/cp/contracts.cc
@@ -161,12 +161,12 @@ contract_valid_p (tree contract)
   return CONTRACT_CONDITION (contract) != error_mark_node;
 }
 
-/* True if the contract attribute is valid.  */
+/* True if the contract specifier is valid.  */
 
 static bool
-contract_attribute_valid_p (tree attribute)
+contract_specifier_valid_p (tree contract)
 {
-  return contract_valid_p (TREE_VALUE (TREE_VALUE (attribute)));
+  return contract_valid_p (TREE_VALUE (TREE_VALUE (contract)));
 }
 
 /* Compare the contract conditions of OLD_CONTRACT and NEW_CONTRACT.
@@ -180,7 +180,7 @@ mismatched_contracts_p (tree old_contract, tree new_contract)
     {
       auto_diagnostic_group d;
       error_at (EXPR_LOCATION (new_contract),
-		"mismatched contract attribute in declaration");
+		"mismatched contract specifier in declaration");
       inform (EXPR_LOCATION (old_contract), "previous contract here");
       return true;
     }
@@ -213,42 +213,42 @@ mismatched_contracts_p (tree old_contract, tree new_contract)
   return false;
 }
 
-/* Compare the contract attributes of OLDDECL and NEWDECL. Returns true
+/* Compare the contract specifiers of OLDDECL and NEWDECL. Returns true
    if the contracts match, and false if they differ.  */
 
 static bool
-match_contract_attributes (location_t oldloc, tree old_attrs,
-			   location_t newloc, tree new_attrs)
+match_contract_specifiers (location_t oldloc, tree old_contracts,
+			   location_t newloc, tree new_contracts)
 {
   /* Contracts only match if they are both specified.  */
-  if (!old_attrs || !new_attrs)
+  if (!old_contracts || !new_contracts)
     return true;
 
   /* Compare each contract in turn.  */
-  while (old_attrs && new_attrs)
+  while (old_contracts && new_contracts)
     {
       /* If either contract is ill-formed, skip the rest of the comparison,
 	 since we've already diagnosed an error.  */
-      if (!contract_attribute_valid_p (new_attrs)
-	  || !contract_attribute_valid_p (old_attrs))
+      if (!contract_specifier_valid_p (new_contracts)
+	  || !contract_specifier_valid_p (old_contracts))
 	return false;
 
-      if (mismatched_contracts_p (CONTRACT_STATEMENT (old_attrs),
-				  CONTRACT_STATEMENT (new_attrs)))
+      if (mismatched_contracts_p (CONTRACT_STATEMENT (old_contracts),
+				  CONTRACT_STATEMENT (new_contracts)))
 	return false;
-      old_attrs = NEXT_CONTRACT_ATTR (old_attrs);
-      new_attrs = NEXT_CONTRACT_ATTR (new_attrs);
+      old_contracts = TREE_CHAIN (old_contracts);
+      new_contracts = TREE_CHAIN (new_contracts);
     }
 
-  /* If we didn't compare all attributes, the contracts don't match.  */
-  if (old_attrs || new_attrs)
+  /* If we didn't compare all contract, the contract specifiers don't match.  */
+  if (old_contracts || new_contracts)
     {
       auto_diagnostic_group d;
       error_at (newloc,
 		"declaration has a different number of contracts than "
 		"previously declared");
       inform (oldloc,
-	      new_attrs
+	      new_contracts
 	      ? "previous declaration with fewer contracts here"
 	      : "previous declaration with more contracts here");
       return false;
@@ -273,7 +273,7 @@ static bool
 has_active_contract_condition (tree fndecl, tree_code c)
 {
   tree as = get_fn_contract_specifiers (fndecl);
-  for (; as != NULL_TREE; as = NEXT_CONTRACT_ATTR (as))
+  for (; as != NULL_TREE; as = TREE_CHAIN (as))
     {
       tree contract = TREE_VALUE (TREE_VALUE (as));
       if (TREE_CODE (contract) == c && contract_active_p (contract))
@@ -305,19 +305,19 @@ static bool
 contract_any_active_p (tree fndecl)
 {
   tree as = get_fn_contract_specifiers (fndecl);
-  for (; as; as = NEXT_CONTRACT_ATTR (as))
+  for (; as; as = TREE_CHAIN (as))
     if (contract_active_p (TREE_VALUE (TREE_VALUE (as))))
       return true;
   return false;
 }
 
-/* Return true if any contract in CONTRACT_ATTRs is not yet parsed.  */
+/* Return true if any contract in CONTRACTS is not yet parsed.  */
 
 bool
-contract_any_deferred_p (tree contract_attr)
+contract_any_deferred_p (tree contracts)
 {
-  for (; contract_attr; contract_attr = NEXT_CONTRACT_ATTR (contract_attr))
-    if (CONTRACT_CONDITION_DEFERRED_P (CONTRACT_STATEMENT (contract_attr)))
+  for (; contracts; contracts = TREE_CHAIN (contracts))
+    if (CONTRACT_CONDITION_DEFERRED_P (CONTRACT_STATEMENT (contracts)))
       return true;
   return false;
 }
@@ -348,22 +348,23 @@ retain_decl (tree decl, copy_body_data *)
   return decl;
 }
 
-/* Copy all contracts from ATTR and apply them to FNDECL.  */
+/* Copy all contracts from CONTRACTS and apply them to FNDECL.  */
 
 static tree
-copy_contracts_list (tree attr, tree fndecl,
+copy_contracts_list (tree contracts, tree fndecl,
 		     contract_match_kind remap_kind = cmk_all)
 {
-  tree last = NULL_TREE, contract_attrs = NULL_TREE;
-  for (; attr; attr = NEXT_CONTRACT_ATTR (attr))
+  tree last = NULL_TREE, new_contracts = NULL_TREE;
+  for (; contracts; contracts = TREE_CHAIN (contracts))
     {
       if ((remap_kind == cmk_pre
-	   && (TREE_CODE (CONTRACT_STATEMENT (attr)) == POSTCONDITION_STMT))
+	  && (TREE_CODE (CONTRACT_STATEMENT (contracts)) == POSTCONDITION_STMT))
 	  || (remap_kind == cmk_post
-	      && (TREE_CODE (CONTRACT_STATEMENT (attr)) == PRECONDITION_STMT)))
+	      && (TREE_CODE(CONTRACT_STATEMENT (contracts))
+		  == PRECONDITION_STMT)))
 	continue;
 
-      tree c = copy_node (attr);
+      tree c = copy_node (contracts);
       TREE_VALUE (c) = build_tree_list (TREE_PURPOSE (TREE_VALUE (c)),
 					copy_node (CONTRACT_STATEMENT (c)));
 
@@ -401,10 +402,10 @@ copy_contracts_list (tree attr, tree fndecl,
 
       chainon (last, c);
       last = c;
-      if (!contract_attrs)
-	contract_attrs = c;
+      if (!new_contracts)
+	new_contracts = c;
     }
-  return contract_attrs;
+  return new_contracts;
 }
 
 /* Lookup a name in std::, or inject it.  */
@@ -627,8 +628,8 @@ parm_used_in_post_p (const_tree decl)
 void
 check_postconditions_in_redecl (tree olddecl, tree newdecl)
 {
-  tree attr = get_fn_contract_specifiers (olddecl);
-  if (!attr)
+  tree contracts = get_fn_contract_specifiers (olddecl);
+  if (!contracts)
     return;
 
   tree t1 = FUNCTION_FIRST_USER_PARM (olddecl);
@@ -1267,8 +1268,8 @@ add_post_condition_fn_call (tree fndecl)
 static tree
 copy_contracts (tree fndecl, contract_match_kind remap_kind = cmk_all)
 {
-  tree attr = get_fn_contract_specifiers (fndecl);
-  return copy_contracts_list (attr, fndecl, remap_kind);
+  tree contracts = get_fn_contract_specifiers (fndecl);
+  return copy_contracts_list (contracts, fndecl, remap_kind);
 }
 
 /* Add the contract statement CONTRACT to the current block if valid.  */
@@ -1288,17 +1289,17 @@ emit_contract_statement (tree contract)
   return true;
 }
 
-/* Generate the statement for the given contract attribute by adding the
+/* Generate the statement for the given contract by adding the contract
    statement to the current block. Returns the next contract in the chain.  */
 
 static tree
-emit_contract_attr (tree attr)
+emit_contract (tree contract)
 {
-  gcc_assert (TREE_CODE (attr) == TREE_LIST);
+  gcc_assert (TREE_CODE (contract) == TREE_LIST);
 
-  emit_contract_statement (CONTRACT_STATEMENT (attr));
+  emit_contract_statement (CONTRACT_STATEMENT (contract));
 
-  return TREE_CHAIN (attr);
+  return TREE_CHAIN (contract);
 }
 
 /* Add a call or a direct evaluation of the pre checks.  */
@@ -1311,8 +1312,8 @@ apply_preconditions (tree fndecl)
   else
   {
     tree contract_copy = copy_contracts (fndecl, cmk_pre);
-    for (; contract_copy; contract_copy = NEXT_CONTRACT_ATTR (contract_copy))
-      emit_contract_attr (contract_copy);
+    for (; contract_copy; contract_copy = TREE_CHAIN (contract_copy))
+      emit_contract (contract_copy);
   }
 }
 
@@ -1326,8 +1327,8 @@ apply_postconditions (tree fndecl)
   else
     {
       tree contract_copy = copy_contracts (fndecl, cmk_post);
-      for (; contract_copy; contract_copy = NEXT_CONTRACT_ATTR (contract_copy))
-	emit_contract_attr (contract_copy);
+      for (; contract_copy; contract_copy = TREE_CHAIN (contract_copy))
+	emit_contract (contract_copy);
     }
 }
 
@@ -1537,17 +1538,17 @@ tree
 copy_and_remap_contracts (tree dest, tree source,
 			  contract_match_kind remap_kind)
 {
-  tree last = NULL_TREE, contract_attrs = NULL_TREE;
-  tree attr = get_fn_contract_specifiers (source);
-  for (; attr; attr = NEXT_CONTRACT_ATTR (attr))
+  tree last = NULL_TREE, contracts_copy = NULL_TREE;
+  tree contract = get_fn_contract_specifiers (source);
+  for (; contract; contract = TREE_CHAIN (contract))
     {
       if ((remap_kind == cmk_pre
-	   && (TREE_CODE (CONTRACT_STATEMENT (attr)) == POSTCONDITION_STMT))
+	   && (TREE_CODE (CONTRACT_STATEMENT (contract)) == POSTCONDITION_STMT))
 	  || (remap_kind == cmk_post
-	      && (TREE_CODE (CONTRACT_STATEMENT (attr)) == PRECONDITION_STMT)))
+	      && (TREE_CODE (CONTRACT_STATEMENT (contract)) == PRECONDITION_STMT)))
 	continue;
 
-      tree c = copy_node (attr);
+      tree c = copy_node (contract);
       TREE_VALUE (c) = build_tree_list (TREE_PURPOSE (TREE_VALUE (c)),
 					copy_node (CONTRACT_STATEMENT (c)));
 
@@ -1569,11 +1570,11 @@ copy_and_remap_contracts (tree dest, tree source,
 
       chainon (last, c);
       last = c;
-      if (!contract_attrs)
-	contract_attrs = c;
+      if (!contracts_copy)
+	contracts_copy = c;
     }
 
-  return contract_attrs;
+  return contracts_copy;
 }
 
 /* Set the (maybe) parsed contract specifier LIST for DECL.  */
@@ -1720,7 +1721,7 @@ check_redecl_contract (tree newdecl, tree olddecl)
       location_t cont_end = get_contract_end_loc (new_contracts);
       cont_end = make_location (new_loc, new_loc, cont_end);
       /* We have two sets - they should match or we issue a diagnostic.  */
-      match_contract_attributes (rdp->note_loc, old_contracts,
+      match_contract_specifiers (rdp->note_loc, old_contracts,
 				 cont_end, new_contracts);
     }
   return;
@@ -1964,7 +1965,7 @@ check_postcondition_result (tree fndecl, tree type, location_t loc)
 }
 
 /* Instantiate each postcondition with the return type to finalize the
-   attribute on a function decl FNDECL.  */
+   contract specifier on a function decl FNDECL.  */
 
 void
 rebuild_postconditions (tree fndecl)
@@ -1973,11 +1974,11 @@ rebuild_postconditions (tree fndecl)
     return;
 
   tree type = TREE_TYPE (TREE_TYPE (fndecl));
-  tree attributes = get_fn_contract_specifiers (fndecl);
+  tree contract_spec = get_fn_contract_specifiers (fndecl);
 
-  for (; attributes ; attributes = NEXT_CONTRACT_ATTR (attributes))
+  for (; contract_spec ; contract_spec = TREE_CHAIN (contract_spec))
     {
-      tree contract = TREE_VALUE (TREE_VALUE (attributes));
+      tree contract = TREE_VALUE (TREE_VALUE (contract_spec));
       if (TREE_CODE (contract) != POSTCONDITION_STMT)
 	continue;
       tree condition = CONTRACT_CONDITION (contract);
@@ -2068,7 +2069,7 @@ build_comment (cp_expr condition)
 /* Build a contract statement.  */
 
 tree
-grok_contract (tree attribute, tree mode, tree result, cp_expr condition,
+grok_contract (tree contract_spec, tree mode, tree result, cp_expr condition,
 	       location_t loc)
 {
   if (condition == error_mark_node)
@@ -2076,18 +2077,18 @@ grok_contract (tree attribute, tree mode, tree result, cp_expr condition,
 
   tree_code code;
   contract_assertion_kind kind = CAK_INVALID;
-  if (is_attribute_p ("assert", attribute)
-      || is_attribute_p ("contract_assert", attribute))
+  if (is_attribute_p ("assert", contract_spec)
+      || is_attribute_p ("contract_assert", contract_spec))
     {
       code = ASSERTION_STMT;
       kind = CAK_ASSERT;
     }
-  else if (is_attribute_p ("pre", attribute))
+  else if (is_attribute_p ("pre", contract_spec))
     {
       code = PRECONDITION_STMT;
       kind = CAK_PRE;
     }
-  else if (is_attribute_p ("post", attribute))
+  else if (is_attribute_p ("post", contract_spec))
     {
       code = POSTCONDITION_STMT;
       kind = CAK_POST;
@@ -2143,25 +2144,25 @@ grok_contract (tree attribute, tree mode, tree result, cp_expr condition,
   return contract;
 }
 
-/* Build the contract attribute specifier where IDENTIFIER is one of 'pre',
-   'post' or 'assert' and CONTRACT is the underlying statement.  */
+/* Build the contract specifier where IDENTIFIER is one of 'pre', 'post' or
+   'assert' and CONTRACT is the underlying statement.  */
 
 tree
-finish_contract_attribute (tree identifier, tree contract)
+finish_contract_specifier (tree identifier, tree contract)
 {
   if (contract == error_mark_node)
     return error_mark_node;
 
-  tree attribute = build_tree_list (build_tree_list (NULL_TREE, identifier),
+  tree contract_spec = build_tree_list (build_tree_list (NULL_TREE, identifier),
 				    build_tree_list (NULL_TREE, contract));
 
   /* Mark the attribute as dependent if the condition is dependent.  */
   tree condition = CONTRACT_CONDITION (contract);
   if (TREE_CODE (condition) != DEFERRED_PARSE
       && value_dependent_expression_p (condition))
-    ATTR_IS_DEPENDENT (attribute) = true;
+    ATTR_IS_DEPENDENT (contract_spec) = true;
 
-  return attribute;
+  return contract_spec;
 }
 
 /* Update condition of a late-parsed contract and postcondition variable,
@@ -2217,16 +2218,16 @@ set_contract_functions (tree fndecl, tree pre, tree post)
 
 
 /* We're compiling the pre/postcondition function CONDFN; remap any FN
-   attributes that match CODE and emit them.  */
+   contracts that match CODE and emit them.  */
 
 static void
 remap_and_emit_conditions (tree fn, tree condfn, tree_code code)
 {
   gcc_assert (code == PRECONDITION_STMT || code == POSTCONDITION_STMT);
-  tree attr = get_fn_contract_specifiers (fn);
-  for (; attr; attr = NEXT_CONTRACT_ATTR (attr))
+  tree contract_spec = get_fn_contract_specifiers (fn);
+  for (; contract_spec; contract_spec = TREE_CHAIN (contract_spec))
     {
-      tree contract = CONTRACT_STATEMENT (attr);
+      tree contract = CONTRACT_STATEMENT (contract_spec);
       if (TREE_CODE (contract) == code)
 	{
 	  contract = copy_node (contract);
@@ -2262,10 +2263,10 @@ finish_function_contracts (tree fndecl)
       && !DECL_CONTRACT_WRAPPER (fndecl))
     return;
 
-  tree attr = get_fn_contract_specifiers (fndecl);
-  for (; attr; attr = NEXT_CONTRACT_ATTR (attr))
+  tree contract_spec = get_fn_contract_specifiers (fndecl);
+  for (; contract_spec; contract_spec = TREE_CHAIN (contract_spec))
     {
-      tree contract = CONTRACT_STATEMENT (attr);
+      tree contract = CONTRACT_STATEMENT (contract_spec);
       if (!CONTRACT_CONDITION (contract)
 	  || CONTRACT_CONDITION (contract) == error_mark_node)
 	return;

--- a/gcc/cp/contracts.h
+++ b/gcc/cp/contracts.h
@@ -29,11 +29,6 @@ along with GCC; see the file COPYING3.  If not see
 
 #include <cstdint>
 
-/* Now our contracts are stored separately from other attributes we
-   can iterate simply... */
-#define NEXT_CONTRACT_ATTR(NODE) \
-  TREE_CHAIN (NODE)
-
 /* Contract assertion kind */
 /* Must match relevant enums in <contracts> header  */
 
@@ -100,7 +95,7 @@ enum detection_mode : uint16_t {
 #define CONTRACT_SOURCE_LOCATION(NODE) \
   (EXPR_LOCATION (CONTRACT_SOURCE_LOCATION_WRAPPER (NODE)))
 
-/* The actual code _STMT for a contract attribute.  */
+/* The actual code _STMT for a contract specifier.  */
 #define CONTRACT_STATEMENT(NODE) \
   (TREE_VALUE (TREE_VALUE (NODE)))
 
@@ -159,7 +154,7 @@ enum contract_match_kind
 /* contracts.cc */
 
 extern tree grok_contract			(tree, tree, tree, cp_expr, location_t);
-extern tree finish_contract_attribute		(tree, tree);
+extern tree finish_contract_specifier 		(tree, tree);
 extern tree finish_contract_condition		(cp_expr);
 extern void update_late_contract		(tree, tree, cp_expr);
 extern void check_redecl_contract		(tree, tree);

--- a/gcc/cp/module.cc
+++ b/gcc/cp/module.cc
@@ -11182,7 +11182,7 @@ trees_out::fn_parms_init (tree fn)
     {
       /* We must walk contract specifiers so the dependency graph is complete. */
       tree contract = get_fn_contract_specifiers (fn);
-      for (; contract; contract = NEXT_CONTRACT_ATTR (contract))
+      for (; contract; contract = TREE_CHAIN (contract))
 	tree_node (contract);
     }
 

--- a/gcc/cp/parser.cc
+++ b/gcc/cp/parser.cc
@@ -32561,7 +32561,7 @@ void cp_parser_late_contracts (cp_parser *parser,
   if (old_contracts == NULL_TREE || !contract_any_deferred_p (old_contracts))
     return;
 
-  for (; old_contracts; old_contracts = NEXT_CONTRACT_ATTR(old_contracts))
+  for (; old_contracts; old_contracts = TREE_CHAIN(old_contracts))
     {
       tree contract = TREE_VALUE(TREE_VALUE (old_contracts));
 
@@ -32808,7 +32808,7 @@ cp_parser_function_contract_specifier (cp_parser *parser)
 static tree
 cp_parser_function_contract_specifier_seq (cp_parser *parser)
 {
-  tree attr_specs = NULL_TREE;
+  tree contract_specs = NULL_TREE;
 
   while (true)
     {
@@ -32826,15 +32826,15 @@ cp_parser_function_contract_specifier_seq (cp_parser *parser)
       tree contract_name = TREE_CODE (contract_spec) == PRECONDITION_STMT
 			   ? get_identifier ("pre")
 			   : get_identifier ("post");
-      tree attr_spec = finish_contract_attribute (contract_name, contract_spec);
+      contract_spec = finish_contract_specifier (contract_name, contract_spec);
       /* Arrange to build the list in the correct order.  */
-      if (attr_specs)
-	attr_specs = attr_chainon (attr_specs, attr_spec);
+      if (contract_specs)
+	contract_specs = attr_chainon (contract_specs, contract_spec);
       else
-	attr_specs = attr_spec;
+	contract_specs = contract_spec;
     }
 
-    return attr_specs;
+    return contract_specs;
 }
 
 /* Parse a standard C++-11 attribute specifier.

--- a/gcc/cp/pt.cc
+++ b/gcc/cp/pt.cc
@@ -12243,7 +12243,7 @@ tsubst_contract_attributes (tree attributes, tree decl, tree args,
 {
   tree subst_contract_list = NULL_TREE;
   for (tree attr = attributes; attr;
-      attr = NEXT_CONTRACT_ATTR (attr))
+      attr = TREE_CHAIN (attr))
   {
       tree nc = copy_node (attr);
       tsubst_contract_attribute (decl, nc, args, complain, in_decl);


### PR DESCRIPTION
Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
